### PR TITLE
Important detail

### DIFF
--- a/examples/utils/get_abide/readme.md
+++ b/examples/utils/get_abide/readme.md
@@ -28,7 +28,7 @@ The `abide.npy` file contains the following contents:
 
 - **timeseries**: Represents the BOLD time series data for each subject. It's a numpy array with the shape (#sub, #ROI, #timesteps).
   
-- > **Label**: Provides the diagnosis label for Autism spectrum disorder for each subject. '0' denotes negative, and '1' indicates positive. It's a numpy array of shape (#sub).
+- > **Label**: Provides the diagnosis label for Autism spectrum disorder for each subject. '0' denotes positive , and '1' indicates negative. It's a numpy array of shape (#sub).
   
 - > **corr**: The correlation matrix calculated from BOLD time series data. It's a numpy array with the shape (#sub, #ROIs, #ROIs).
   


### PR DESCRIPTION
Upon reviewing the phenotypic data file, I've noticed an inconsistency in the definitions. When DX_GROUP = 1 (indicating autism), the label is set as 0, whereas in the README file, 0 is labeled as "negative" (non-afflicted). For instance, for patient 50643 (male, 21 years old, diagnosed with autism), the label in abide.npy is 0 (negative).